### PR TITLE
fix: parseInt of urlExpiration + xray:PutTraceSegments perm for getImages

### DIFF
--- a/course-04/exercises/lesson-4/solution/src/lambda/http/createImage.ts
+++ b/course-04/exercises/lesson-4/solution/src/lambda/http/createImage.ts
@@ -88,6 +88,6 @@ function getUploadUrl(imageId: string) {
   return s3.getSignedUrl('putObject', {
     Bucket: bucketName,
     Key: imageId,
-    Expires: urlExpiration
+    Expires: parseInt(urlExpiration)
   })
 }

--- a/course-04/exercises/lesson-6/starter-code/serverless.yml
+++ b/course-04/exercises/lesson-6/starter-code/serverless.yml
@@ -157,6 +157,10 @@ functions:
         Action:
           - dynamodb:GetItem
         Resource: arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.GROUPS_TABLE}
+      - Effect: Allow
+        Action:
+        - xray:PutTraceSegments
+        Resource: "*"
 
   CreateImage:
     handler: src/lambda/http/createImage.handler


### PR DESCRIPTION
For some reason, AWS complained about receiving a string here, even though the declaration in serverless.yml is clearly an int.

