### PR TITLE
Fixes issue where stubbed methods were failing to compile during build

### DIFF
--- a/course-02/exercises/udacity-c2-restapi/src/controllers/v0/users/routes/auth.router.ts
+++ b/course-02/exercises/udacity-c2-restapi/src/controllers/v0/users/routes/auth.router.ts
@@ -12,14 +12,17 @@ const router: Router = Router();
 
 async function generatePassword(plainTextPassword: string): Promise<string> {
     //@TODO Use Bcrypt to Generated Salted Hashed Passwords
+    return 'REPLACE ME'
 }
 
 async function comparePasswords(plainTextPassword: string, hash: string): Promise<boolean> {
     //@TODO Use Bcrypt to Compare your password to your Salted Hashed Password
+    return false
 }
 
 function generateJWT(user: User): string {
     //@TODO Use jwt to create a new JWT Payload containing
+    return 'REPLACE ME'
 }
 
 export function requireAuth(req: Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
The following stubbed methods in `auth.router.ts` declare a return type but do not return a value:
- `generatePassword`
- `comparePasswords`
- `generateJWT`

In Lesson 4: Building and Deploying (Part 7 - Deploying Our Server to the Cloud) the student is guided to run the `npm run build` command but because of these missing return values the build fails with the following errors

```shell
╰─❯ npm run build                                                                                                                                                                                        ─╯

> udacity-c2-restapi@1.0.0 build /Users/forsythetony/Documents/learning/udacity/aws_cloud_developer/section-3_full-stack-apps-on-aws/cloud-developer/course-02/exercises/udacity-c2-restapi
> npm run clean && tsc && cp -rf src/config www/config && cp .npmrc www/.npmrc && cp package.json www/package.json && cd www && zip -r Archive.zip . && cd ..


> udacity-c2-restapi@1.0.0 clean /Users/forsythetony/Documents/learning/udacity/aws_cloud_developer/section-3_full-stack-apps-on-aws/cloud-developer/course-02/exercises/udacity-c2-restapi
> rm -rf www/ || true

src/controllers/v0/users/routes/auth.router.ts:13:61 - error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.

13 async function generatePassword(plainTextPassword: string): Promise<string> {
                                                               ~~~~~~~~~~~~~~~

src/controllers/v0/users/routes/auth.router.ts:17:75 - error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.

17 async function comparePasswords(plainTextPassword: string, hash: string): Promise<boolean> {
                                                                             ~~~~~~~~~~~~~~~~

src/controllers/v0/users/routes/auth.router.ts:21:35 - error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.

21 function generateJWT(user: User): string {
                                     ~~~~~~


Found 3 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! udacity-c2-restapi@1.0.0 build: `npm run clean && tsc && cp -rf src/config www/config && cp .npmrc www/.npmrc && cp package.json www/package.json && cd www && zip -r Archive.zip . && cd ..`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the udacity-c2-restapi@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/forsythetony/.npm/_logs/2020-04-14T03_12_22_354Z-debug.log
```

This PR adds some placeholder return values to get the build passing.