### PR TITLE
Fix patch id router by using status method instead of send method

### DIFF
--- a/course-02/exercises/udacity-c2-restapi/src/controllers/v0/feed/routes/feed.router.ts
+++ b/course-02/exercises/udacity-c2-restapi/src/controllers/v0/feed/routes/feed.router.ts
@@ -24,7 +24,7 @@ router.patch('/:id',
     requireAuth, 
     async (req: Request, res: Response) => {
         //@TODO try it yourself
-        res.send(500).send("not implemented")
+        res.status(500).send("not implemented")
 });
 
 


### PR DESCRIPTION
Fix boiler template of router.path('/:id', ...)
status code should be set using status method from Response instead of send