### PR TITLE
Fix Sequelize for Node 14+

### DIFF
--- a/course-02/exercises/udacity-c2-restapi/package.json
+++ b/course-02/exercises/udacity-c2-restapi/package.json
@@ -24,9 +24,9 @@
     "email-validator": "^2.0.4",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "pg": "^7.11.0",
+    "pg": "^8.0.3",
     "reflect-metadata": "^0.1.13",
-    "sequelize": "^5.10.0",
+    "sequelize": "^5.21.7",
     "sequelize-typescript": "^0.6.11"
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "mocha": "^6.1.4",
+    "sequelize-cli": "^5.5.1",
     "ts-node-dev": "^1.0.0-pre.40",
     "tslint": "^5.18.0",
     "typescript": "^3.5.3"


### PR DESCRIPTION
The restapi project is broken for Node 14+
https://knowledge.udacity.com/questions/169533

This Sequelize issue discovered that upgrading PG fixes the problem.
https://github.com/sequelize/sequelize/issues/12158