### PR TITLE
Main file path fix

### DIFF
--- a/course-02/exercises/udacity-c2-restapi/package.json
+++ b/course-02/exercises/udacity-c2-restapi/package.json
@@ -2,7 +2,7 @@
   "name": "udacity-c2-restapi",
   "version": "1.0.0",
   "description": "",
-  "main": "src/server.js",
+  "main": "server.js",
   "scripts": {
     "start": "node .",
     "tsc": "tsc",


### PR DESCRIPTION
When the transpiler transpiles the code, it does not create a `src` directory inside `www` directory. The `server.js` file is in the root of `www` directory. In this way, when the transpiled code is run, it fails because it cannot find `www/src/server.js`.