### PR TITLE
Added s3_cors.json because AWS no longer supports XML in the CORS policy section.

### DIFF
--- a/course-02/exercises/udacity-c2-basic-server/s3_cors.json
+++ b/course-02/exercises/udacity-c2-basic-server/s3_cors.json
@@ -1,0 +1,17 @@
+[
+    {
+        "AllowedOrigins": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "POST",
+            "GET",
+            "PUT",
+            "DELETE",
+            "HEAD"
+        ],
+        "AllowedHeaders": [
+            "*"
+        ]
+    }
+]


### PR DESCRIPTION
When adding a CORS policy to an S3 bucket, the exercise provides a policy written in XML. However, AWS no longer supports XML in this section and requires it to be written in JSON format. This is the JSON version of the XML file provided by Udacity.