### PR TITLE
Serverless => update package.json and package-lock

### DIFF
--- a/course-04/exercises/c4-demos-master/04-chaos-monkey/package-lock.json
+++ b/course-04/exercises/c4-demos-master/04-chaos-monkey/package-lock.json
@@ -1,19 +1,179 @@
 {
   "name": "serverless-chaos-monkey",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "serverless-chaos-monkey",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "aws-sdk": "^2.1106.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1106.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1106.0.tgz",
+      "integrity": "sha512-3dr0TTR2LI70ST8fa4IgXHpWdH4yv7FLnt9YEndwFQ8ar2EMCMpMU67wwCGBA72GUi0aOg4+lsLjGmCvIq3jug==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
-      "version": "2.432.0",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/aws-sdk/-/aws-sdk-2.432.0.tgz",
-      "integrity": "sha512-1Ly0chGU8K+r/8zM5iBiCC5MHOc4h/xReTv1VlRpemL5Fq2ndY6R5/uEEJ8ioqyd2UNban/w6LKwtOB1NF9IWg==",
+      "version": "2.1106.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1106.0.tgz",
+      "integrity": "sha512-3dr0TTR2LI70ST8fa4IgXHpWdH4yv7FLnt9YEndwFQ8ar2EMCMpMU67wwCGBA72GUi0aOg4+lsLjGmCvIq3jug==",
       "dev": true,
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
-        "jmespath": "0.15.0",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -22,15 +182,15 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -45,27 +205,27 @@
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "punycode": {
       "version": "1.3.2",

--- a/course-04/exercises/c4-demos-master/04-chaos-monkey/package.json
+++ b/course-04/exercises/c4-demos-master/04-chaos-monkey/package.json
@@ -10,9 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "aws-sdk": "^2.432.0"
+    "aws-sdk": "^2.1106.0"
   }
 }

--- a/course-04/exercises/c4-demos-master/05-http-metrics/package-lock.json
+++ b/course-04/exercises/c4-demos-master/05-http-metrics/package-lock.json
@@ -1,19 +1,213 @@
 {
     "name": "serverless-http-metrics",
     "version": "1.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "serverless-http-metrics",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "aws-sdk": "^2.1110.0",
+                "axios": "^0.18.0"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1110.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1110.0.tgz",
+            "integrity": "sha512-qxHqzE2ikGNRzhajcmWIBuptML3LBwz9TMnS0jLQjXOP54fZYW6EEKy2Dy7MKjHKeo8QQy/EWtDdWfH9Fu5UIA==",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+            "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+            "dependencies": {
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "dependencies": {
+                "debug": "=3.1.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "node_modules/is-buffer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    },
     "dependencies": {
         "aws-sdk": {
-            "version": "2.437.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/aws-sdk/-/aws-sdk-2.437.0.tgz",
-            "integrity": "sha512-sDZb5QBOO6FOMvuKDEdO16YQRk0WUhnQd38EaSt0yUCi4Gev8uypODyYONgODZcXe8Cr1GMwC8scUKr00S/I5w==",
-            "dev": true,
+            "version": "2.1110.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1110.0.tgz",
+            "integrity": "sha512-qxHqzE2ikGNRzhajcmWIBuptML3LBwz9TMnS0jLQjXOP54fZYW6EEKy2Dy7MKjHKeo8QQy/EWtDdWfH9Fu5UIA==",
             "requires": {
-                "buffer": "4.9.1",
+                "buffer": "4.9.2",
                 "events": "1.1.1",
-                "ieee754": "1.1.8",
-                "jmespath": "0.15.0",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
@@ -22,25 +216,23 @@
             }
         },
         "axios": {
-            "version": "0.18.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/axios/-/axios-0.18.0.tgz",
-            "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
             "requires": {
-                "follow-redirects": "^1.3.0",
-                "is-buffer": "^1.1.5"
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
             }
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-            "dev": true
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-            "dev": true,
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -48,78 +240,70 @@
             }
         },
         "debug": {
-            "version": "3.2.6",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/debug/-/debug-3.2.6.tgz",
-            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.0.0"
             }
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "follow-redirects": {
-            "version": "1.7.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/follow-redirects/-/follow-redirects-1.7.0.tgz",
-            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
             "requires": {
-                "debug": "^3.2.6"
+                "debug": "=3.1.0"
             }
         },
         "ieee754": {
-            "version": "1.1.8",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ieee754/-/ieee754-1.1.8.tgz",
-            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-            "dev": true
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
         },
         "isarray": {
             "version": "1.0.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "jmespath": {
-            "version": "0.15.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-            "dev": true
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
         },
         "ms": {
-            "version": "2.1.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "punycode": {
             "version": "1.3.2",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         },
         "querystring": {
             "version": "0.2.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "sax": {
             "version": "1.2.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "url": {
             "version": "0.10.3",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/url/-/url-0.10.3.tgz",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
             "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-            "dev": true,
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
@@ -127,15 +311,13 @@
         },
         "uuid": {
             "version": "3.3.2",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "xml2js": {
             "version": "0.4.19",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xml2js/-/xml2js-0.4.19.tgz",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~9.0.1"
@@ -143,9 +325,8 @@
         },
         "xmlbuilder": {
             "version": "9.0.7",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
     }
 }

--- a/course-04/exercises/c4-demos-master/05-http-metrics/package.json
+++ b/course-04/exercises/c4-demos-master/05-http-metrics/package.json
@@ -10,9 +10,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "aws-sdk": "^2.1110.0",
         "axios": "^0.18.0"
-    },
-    "devDependencies": {
-        "aws-sdk": "^2.432.0"
     }
 }

--- a/course-04/exercises/c4-demos-master/08-dynamodb-create/package-lock.json
+++ b/course-04/exercises/c4-demos-master/08-dynamodb-create/package-lock.json
@@ -1,19 +1,157 @@
 {
     "name": "dynamodb-create-function",
     "version": "1.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "dynamodb-create-function",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "aws-sdk": "^2.1110.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1110.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1110.0.tgz",
+            "integrity": "sha512-qxHqzE2ikGNRzhajcmWIBuptML3LBwz9TMnS0jLQjXOP54fZYW6EEKy2Dy7MKjHKeo8QQy/EWtDdWfH9Fu5UIA==",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    },
     "dependencies": {
         "aws-sdk": {
-            "version": "2.437.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/aws-sdk/-/aws-sdk-2.437.0.tgz",
-            "integrity": "sha512-sDZb5QBOO6FOMvuKDEdO16YQRk0WUhnQd38EaSt0yUCi4Gev8uypODyYONgODZcXe8Cr1GMwC8scUKr00S/I5w==",
-            "dev": true,
+            "version": "2.1110.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1110.0.tgz",
+            "integrity": "sha512-qxHqzE2ikGNRzhajcmWIBuptML3LBwz9TMnS0jLQjXOP54fZYW6EEKy2Dy7MKjHKeo8QQy/EWtDdWfH9Fu5UIA==",
             "requires": {
-                "buffer": "4.9.1",
+                "buffer": "4.9.2",
                 "events": "1.1.1",
-                "ieee754": "1.1.8",
-                "jmespath": "0.15.0",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
@@ -22,16 +160,14 @@
             }
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-            "dev": true
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-            "dev": true,
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -40,51 +176,43 @@
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "ieee754": {
-            "version": "1.1.8",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ieee754/-/ieee754-1.1.8.tgz",
-            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-            "dev": true
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "isarray": {
             "version": "1.0.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "jmespath": {
-            "version": "0.15.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-            "dev": true
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
         },
         "punycode": {
             "version": "1.3.2",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         },
         "querystring": {
             "version": "0.2.0",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "sax": {
             "version": "1.2.1",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "url": {
             "version": "0.10.3",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/url/-/url-0.10.3.tgz",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
             "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-            "dev": true,
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
@@ -97,9 +225,8 @@
         },
         "xml2js": {
             "version": "0.4.19",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xml2js/-/xml2js-0.4.19.tgz",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~9.0.1"
@@ -107,9 +234,8 @@
         },
         "xmlbuilder": {
             "version": "9.0.7",
-            "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
     }
 }

--- a/course-04/exercises/c4-demos-master/08-dynamodb-create/package.json
+++ b/course-04/exercises/c4-demos-master/08-dynamodb-create/package.json
@@ -10,9 +10,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "aws-sdk": "^2.1110.0",
         "uuid": "^3.3.2"
-    },
-    "devDependencies": {
-        "aws-sdk": "^2.432.0"
     }
 }

--- a/course-04/exercises/lesson-1/starter-code/package-lock.json
+++ b/course-04/exercises/lesson-1/starter-code/package-lock.json
@@ -1,19 +1,216 @@
 {
     "name": "serverless-http-metrics",
     "version": "1.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "serverless-http-metrics",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "axios": "^0.18.1"
+            },
+            "devDependencies": {
+                "aws-sdk": "^2.492.0"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1106.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1106.0.tgz",
+            "integrity": "sha512-3dr0TTR2LI70ST8fa4IgXHpWdH4yv7FLnt9YEndwFQ8ar2EMCMpMU67wwCGBA72GUi0aOg4+lsLjGmCvIq3jug==",
+            "dev": true,
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+            "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+            "dependencies": {
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dev": true,
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "dependencies": {
+                "debug": "=3.1.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
+        },
+        "node_modules/is-buffer": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "dev": true
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "dev": true
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dev": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dev": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    },
     "dependencies": {
         "aws-sdk": {
-            "version": "2.492.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.492.0.tgz",
-            "integrity": "sha512-9Mj4nNXoxUehLaeoGE53eLOdOUtkQyTmkAkofK+gbXxfB+V1cXYngdUJwTaRpKx4OJHy4ntKoP+JRvvScD6XeA==",
+            "version": "2.1106.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1106.0.tgz",
+            "integrity": "sha512-3dr0TTR2LI70ST8fa4IgXHpWdH4yv7FLnt9YEndwFQ8ar2EMCMpMU67wwCGBA72GUi0aOg4+lsLjGmCvIq3jug==",
             "dev": true,
             "requires": {
-                "buffer": "4.9.1",
+                "buffer": "4.9.2",
                 "events": "1.1.1",
-                "ieee754": "1.1.8",
-                "jmespath": "0.15.0",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
@@ -31,15 +228,15 @@
             }
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
@@ -70,9 +267,9 @@
             }
         },
         "ieee754": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "dev": true
         },
         "is-buffer": {
@@ -87,9 +284,9 @@
             "dev": true
         },
         "jmespath": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
             "dev": true
         },
         "ms": {


### PR DESCRIPTION
Sir/Ma'am,
Since the Course-04 exercises were erroring out , I reported the issue and am creating this pull request.  I went through some of the folders and updated the package.json to reflect aws-sdk 2.1110, which as of the date of this PR, is the most current version of 2.X on npm (https://www.npmjs.com/package/aws-sdk/v/2.1110.0).  Please note, I installed them as a regular package rather than dev-dependency, since these are all instructional materials and are not meant for a production environment.

The package-lock.json files also now point to npm as their sources rather than the nexus.solutions endpoints.  With these changes, when a student runs 'npm i' they should not run into any errors.  That is pretty much it.  If you have any questions, comments, or concerns, please do not hesitate to let me know.  Thank you and have a wonderful day.

Note: With this PR, I did not get all of them.  I realized shortly after pushing that the  './course-4/exercises/lesson-x' projects all have the same problem as above.  I had made changes on my branch and will create another PR after this one is submitted with the new changes I have.  Additionally, I removed the .zip file in lesson-1, I forgot about it with the original push.


V/R
Michael Mason