### PR TITLE
fix: prevent posting duplicate records

### DIFF
--- a/course-02/exercises/udacity-c2-frontend/src/app/api/api.service.ts
+++ b/course-02/exercises/udacity-c2-frontend/src/app/api/api.service.ts
@@ -63,7 +63,7 @@ export class ApiService {
 
     return new Promise ( resolve => {
         this.http.request(req).subscribe((resp) => {
-        if (resp && (<any> resp).status && (<any> resp).status === 200) {
+        if (resp && resp.type === HttpEventType.Response && (<any> resp).status && (<any> resp).status === 200) {
           resolve(this.post(endpoint, payload));
         }
       });


### PR DESCRIPTION
prevent the posting to the feed multiple times after the response from S3 by also checking the resp type