### PR TITLE
Updated the pg library to the latest, the old version was preventing sequelize.sync() from executing on node 14+ (module - udacity-c2-restapi)

### DIFF
--- a/course-02/exercises/udacity-c2-restapi/package.json
+++ b/course-02/exercises/udacity-c2-restapi/package.json
@@ -24,7 +24,7 @@
     "email-validator": "^2.0.4",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "pg": "^7.11.0",
+    "pg": "^8.7.3",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^5.10.0",
     "sequelize-typescript": "^0.6.11"


### PR DESCRIPTION
the older version of pg was preventing sequelize.sync() from executing on node 14+

