### PR TITLE
fix: set type for caught exception e

### DIFF
--- a/course-04/project/c4-final-project-starter-code/client/src/components/EditTodo.tsx
+++ b/course-04/project/c4-final-project-starter-code/client/src/components/EditTodo.tsx
@@ -58,7 +58,7 @@ export class EditTodo extends React.PureComponent<
 
       alert('File was uploaded!')
     } catch (e) {
-      alert('Could not upload a file: ' + e.message)
+      alert('Could not upload a file: ' + (e as Error).message)
     } finally {
       this.setUploadState(UploadState.NoUpload)
     }

--- a/course-04/project/c4-final-project-starter-code/client/src/components/Todos.tsx
+++ b/course-04/project/c4-final-project-starter-code/client/src/components/Todos.tsx
@@ -97,7 +97,7 @@ export class Todos extends React.PureComponent<TodosProps, TodosState> {
         loadingTodos: false
       })
     } catch (e) {
-      alert(`Failed to fetch todos: ${e.message}`)
+      alert(`Failed to fetch todos: ${(e as Error).message}`)
     }
   }
 


### PR DESCRIPTION
#### What does this PR solve?
This PR solves the Typescript error that is thrown when trying to access the `message` property on a caught exception `e`, which appears as an unknown object to Typescript.

#### The Fix
The fix provided is to cast the caught exception `e` as an `Error` type. With this, you can access other properties of `Error` such as `name` `stack` e.t.c
